### PR TITLE
Add `Warden::WebAuthn::RackHelpers`; prepend to `StrategyHelpers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Refactor `relying_party_key` into `Warden::WebAuthn::RackHelpers`
+  - https://github.com/ruby-passkeys/warden-webauthn/issues/4
+
 ## [0.1.0] - 2023-02-04
 
 - Initial release

--- a/lib/warden/webauthn.rb
+++ b/lib/warden/webauthn.rb
@@ -2,6 +2,7 @@
 
 require_relative "webauthn/version"
 require_relative "webauthn/error_key_finder"
+require_relative "webauthn/rack_helpers"
 require_relative "webauthn/strategy_helpers"
 require_relative "webauthn/strategy"
 require_relative "webauthn/authentication_initiation_helpers"

--- a/lib/warden/webauthn/rack_helpers.rb
+++ b/lib/warden/webauthn/rack_helpers.rb
@@ -1,0 +1,9 @@
+module Warden
+  module WebAuthn
+    module RackHelpers
+      def relying_party_key
+        "warden.webauthn.relying_party"
+      end
+    end
+  end
+end

--- a/lib/warden/webauthn/rack_helpers.rb
+++ b/lib/warden/webauthn/rack_helpers.rb
@@ -1,5 +1,10 @@
+# frozen_string_literal: true
+
+
 module Warden
   module WebAuthn
+    # Helpers that can be mixed in to any Rack middleware or application, in order
+    # to setup the environment for `Warden::WebAuthn`, such as the Relying Party
     module RackHelpers
       def relying_party_key
         "warden.webauthn.relying_party"

--- a/lib/warden/webauthn/rack_helpers.rb
+++ b/lib/warden/webauthn/rack_helpers.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 module Warden
   module WebAuthn
     # Helpers that can be mixed in to any Rack middleware or application, in order

--- a/lib/warden/webauthn/rack_helpers.rb
+++ b/lib/warden/webauthn/rack_helpers.rb
@@ -8,6 +8,10 @@ module Warden
       def relying_party_key
         "warden.webauthn.relying_party"
       end
+
+      def set_relying_party_in_request_env
+        request.env[relying_party_key] = relying_party
+      end
     end
   end
 end

--- a/lib/warden/webauthn/strategy_helpers.rb
+++ b/lib/warden/webauthn/strategy_helpers.rb
@@ -7,6 +7,7 @@ module Warden
     # Helpers that can be mixed in to any WebAuthn-related code, such as custom strategies or
     # an app's authentication flow
     module StrategyHelpers
+      prepend RackHelpers
       class NoStoredCredentialFound < StandardError; end
 
       # rubocop:disable Metrics/MethodLength

--- a/test/warden/test_rack_helpers.rb
+++ b/test/warden/test_rack_helpers.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Warden::TestRackHelpers < Minitest::Test
+  class TestClass
+    include Warden::WebAuthn::RackHelpers
+  end
+
+  class CustomizedClass
+    include Warden::WebAuthn::RackHelpers
+
+    def relying_party_key
+      "custom_relying_party"
+    end
+  end
+
+  def test_default_keys
+    assert_equal "warden.webauthn.relying_party", TestClass.new.relying_party_key
+  end
+
+  def test_custom_keys
+    assert_equal "custom_relying_party", CustomizedClass.new.relying_party_key
+  end
+end

--- a/test/warden/test_rack_helpers.rb
+++ b/test/warden/test_rack_helpers.rb
@@ -5,13 +5,29 @@ require "test_helper"
 class Warden::TestRackHelpers < Minitest::Test
   class TestClass
     include Warden::WebAuthn::RackHelpers
+
+    attr_accessor :request
+
+    def initialize
+      self.request = Rack::Request.new({})
+    end
   end
 
   class CustomizedClass
     include Warden::WebAuthn::RackHelpers
 
+    attr_accessor :request
+
+    def initialize
+      self.request = Rack::Request.new({})
+    end
+
     def relying_party_key
       "custom_relying_party"
+    end
+
+    def relying_party
+      "dummy_relying_party_value"
     end
   end
 
@@ -21,5 +37,17 @@ class Warden::TestRackHelpers < Minitest::Test
 
   def test_custom_keys
     assert_equal "custom_relying_party", CustomizedClass.new.relying_party_key
+  end
+
+  def test_raises_name_error_if_no_relying_party_method
+    assert_raises NameError do
+      TestClass.new.set_relying_party_in_request_env
+    end
+  end
+
+  def test_raises_uses_defined_relying_party_method
+    instance = CustomizedClass.new
+    instance.set_relying_party_in_request_env
+    assert_equal "dummy_relying_party_value", instance.request.env["custom_relying_party"]
   end
 end


### PR DESCRIPTION
* In order to provide a clean, isolated module for other libraries to use the centralized default `relying_party_key`, we need to:
	* Break out the relying_party_key into a new `Warden::WebAuthn::RackHelpers` module
	* Auto-include that module as part of `Warden::WebAuthn::StrategyHelpers` to achieve the same goal of a centrally located default key


(@Vagab I can't officially tag you as a reviewer on this, but would definitely appreciate your feedback since we've been working on this)

This closes #4 